### PR TITLE
Add another mermaid extension

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,7 +79,6 @@ extra:
       make our documentation better.
 plugins:
   - search
-  - mermaid2
   - glightbox
 
 nav:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,11 @@ markdown_extensions:
   - toc:
       permalink: "#"
       title: On this page
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
 extra:
   analytics:
     provider: google

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 mkdocs-material>=9.5.2,<10.0.0
-mkdocs-mermaid2-plugin>=1.1.1,<2.0.0
 mkdocs-glightbox>=0.3.5,<1.0.0


### PR DESCRIPTION
Mermaid2 is not able to render mermaid diagrams in mto-docs, adding another mermaid extension which works as expected