### PR TITLE
Remove mermaid2 plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,5 @@ extra:
 plugins:
   - search
   - glightbox
-  - mermaid2
 
 nav:


### PR DESCRIPTION
When building docs with latest theme:
```sh
ERROR   -  Config value 'plugins': The "mermaid2" plugin is not installed
```