### PR TITLE
Add spell checking of HTML files

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -10,5 +10,5 @@ jobs:
     uses: stakater/.github/.github/workflows/pull_request_doc_qa.yaml@v0.0.82
     with:
       MD_CONFIG: .github/md_config.json
-      DOC_SRC: README.md
+      DOC_SRC: README.md resources
       MD_LINT_CONFIG: .markdownlint.yaml

--- a/.vale.ini
+++ b/.vale.ini
@@ -4,7 +4,7 @@ MinAlertLevel = warning
 Packages = https://github.com/stakater/vale-package/releases/download/v0.0.27/Stakater.zip
 Vocab = Stakater
 
-# Only check MarkDown files
-[*.md]
+# Only check MarkDown and HTML files
+[*.{md,html}]
 
 BasedOnStyles = Vale

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,7 +1,7 @@
 StylesPath = styles
 MinAlertLevel = warning
 
-Packages = https://github.com/stakater/vale-package/releases/download/v0.0.27/Stakater.zip
+Packages = https://github.com/stakater/vale-package/releases/download/v0.0.29/Stakater.zip
 Vocab = Stakater
 
 # Only check MarkDown and HTML files

--- a/resources/partials/footer.html
+++ b/resources/partials/footer.html
@@ -322,7 +322,6 @@
                         <a href="https://github.com/stakater" class="svg-container" title="GitHub">
                             <!-- vale off -->
                             {% include "assets/svg/social/github.svg" %}
-                            <!-- vale on -->
                         </a>
                         <a href="https://www.linkedin.com/company/stakater/" class="svg-container" title="LinkedIn">
                             {% include "assets/svg/social/linkedin.svg" %}
@@ -339,7 +338,9 @@
                         <a href="https://www.reddit.com/user/stakater/" class="svg-container" title="Reddit">
                             {% include "assets/svg/social/reddit.svg" %}
                         </a>
+                        
                     </div>
+                    <!-- vale on -->
                 </div>
             </div>
         </div>

--- a/resources/partials/footer.html
+++ b/resources/partials/footer.html
@@ -124,7 +124,7 @@
                         </p>
                         <p class="md-footer-org-details-md">
 
-                            David Bagaers gata 26A, <br>
+                            David Bagares gata 26A, <br>
                             111 38 Stockholm, <br>
                             Sweden
 
@@ -319,10 +319,12 @@
                 <div class="flex-1">
                     <!-- Social Links -->
                     <div class="display-flex jscsa">
-                        <a href="https://github.com/stakater" class="svg-container" title="Github">
+                        <a href="https://github.com/stakater" class="svg-container" title="GitHub">
+                            <!-- vale off -->
                             {% include "assets/svg/social/github.svg" %}
+                            <!-- vale on -->
                         </a>
-                        <a href="https://www.linkedin.com/company/stakater/" class="svg-container" title="Linkedin">
+                        <a href="https://www.linkedin.com/company/stakater/" class="svg-container" title="LinkedIn">
                             {% include "assets/svg/social/linkedin.svg" %}
                         </a>
                         <a href="https://x.com/stakater" class="svg-container" title="X">

--- a/resources/partials/footer.html
+++ b/resources/partials/footer.html
@@ -318,9 +318,9 @@
                 <div class="flex-1"></div> -->
                 <div class="flex-1">
                     <!-- Social Links -->
+                    <!-- vale off -->
                     <div class="display-flex jscsa">
                         <a href="https://github.com/stakater" class="svg-container" title="GitHub">
-                            <!-- vale off -->
                             {% include "assets/svg/social/github.svg" %}
                         </a>
                         <a href="https://www.linkedin.com/company/stakater/" class="svg-container" title="LinkedIn">
@@ -338,7 +338,6 @@
                         <a href="https://www.reddit.com/user/stakater/" class="svg-container" title="Reddit">
                             {% include "assets/svg/social/reddit.svg" %}
                         </a>
-                        
                     </div>
                     <!-- vale on -->
                 </div>

--- a/resources/partials/nav-links.html
+++ b/resources/partials/nav-links.html
@@ -156,13 +156,13 @@
                         </div>
                         <div class="dropdown-content-anchor-container">
                             <a href="https://www.stakater.com/openshift-as-a-service"
-                                class="dropdown-item-link-text hover-underline">Openshift
+                                class="dropdown-item-link-text hover-underline">OpenShift
                                 Consultancy</a>
                         </div>
                         <div class="dropdown-content-anchor-container">
                             <a href="https://www.stakater.com/secure-your-kubernetes-infrastructure"
                                 class="dropdown-item-link-text hover-underline">Secret
-                                Managment Service</a>
+                                Management Service</a>
                         </div>
                         <div class="dropdown-content-anchor-container">
                             <a href="https://www.stakater.com/kubernetes-consultancy"
@@ -190,7 +190,7 @@
                     <!-- Column 4 -->
                     <div class="dropdown-content-dev-links">
                         <div class="dropdown-content-dev-links-anchor-container">
-                            <a href="https://github.com/stakater/" class="dropdown-content-dev-links-anchor">Github</a>
+                            <a href="https://github.com/stakater/" class="dropdown-content-dev-links-anchor">GitHub</a>
                         </div>
                         <div class="dropdown-content-dev-links-anchor-container">
                             <a href="https://docs.stakater.com/"


### PR DESCRIPTION
Vale need to be turned off for `footer.html` in the div containing `{% include "assets/svg/social/github.svg" %}`, otherwise it will error out on the include href, although it is not text. Turning off has to be done on the div level, otherwise the turning on doesn't work as expected.