### PR TITLE
Revert to earlier version of anothrNick/github-tag-action

### DIFF
--- a/.github/workflows/push_container.yaml
+++ b/.github/workflows/push_container.yaml
@@ -6,7 +6,7 @@ on:
       - 'main'
 
 jobs:
-  build:
+  push:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/.github/workflows/push_container.yaml
+++ b/.github/workflows/push_container.yaml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
 
       - name: Push Latest Tag
-        uses: anothrNick/github-tag-action@1.70.0
+        uses: anothrNick/github-tag-action@1.62.0
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
           WITH_V: true


### PR DESCRIPTION
Getting unauthorized error although the token has write permissions for the repo, reverting to a version that has worked before:

```
Bumping tag v0.0.33 - New tag v0.0.34
EVENT: creating local tag v0.0.34
EVENT: pushing tag v0.0.34 to origin
2024-09-10T15:30:01Z: **pushing tag v0.0.34 to repo stakater/stakater-docs-mkdocs-theme
  "message": "Bad credentials",
  "documentation_url": "https://docs.github.com/rest",
  "status": "401"
}
```

Also correct the job name.