### PR TITLE
Update the outdated banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,5 +112,4 @@ Versioning is provided by `theme_override` and can be added to the `mkdocs.yml` 
 
 It is compiled under the `dist/_theme`
 
-> Tip: Copy the [`prepare_theme.sh`](./prepare_theme.sh) file to your project and run it to avoid having to remember to run all commands in step 4
-> Tip: Use the [`prepare_theme_pr.sh`](./prepare_theme_pr.sh) in your pull request builds to generate pull request specific overrides
+> Tip: Copy the [`prepare_theme.sh`](./prepare_theme.sh) file to your project and run it to avoid having to remember to run all commands in step 4. Use the [`prepare_theme_pr.sh`](./prepare_theme_pr.sh) in your pull request builds to generate pull request specific overrides.

--- a/README.md
+++ b/README.md
@@ -113,5 +113,4 @@ Versioning is provided by `theme_override` and can be added to the `mkdocs.yml` 
 It is compiled under the `dist/_theme`
 
 > Tip: Copy the [`prepare_theme.sh`](./prepare_theme.sh) file to your project and run it to avoid having to remember to run all commands in step 4
-
 > Tip: Use the [`prepare_theme_pr.sh`](./prepare_theme_pr.sh) in your pull request builds to generate pull request specific overrides

--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ Versioning is provided by `theme_override` and can be added to the `mkdocs.yml` 
 
 It is compiled under the `dist/_theme`
 
-> Tip: Copy `prepare_theme.sh` file to your project and run it to avoid the above scripts in step 4.
+> Tip: Copy the [`prepare_theme.sh`](./prepare_theme.sh) file to your project and run it to avoid having to remember to run all commands in step 4.

--- a/README.md
+++ b/README.md
@@ -112,4 +112,6 @@ Versioning is provided by `theme_override` and can be added to the `mkdocs.yml` 
 
 It is compiled under the `dist/_theme`
 
-> Tip: Copy the [`prepare_theme.sh`](./prepare_theme.sh) file to your project and run it to avoid having to remember to run all commands in step 4.
+> Tip: Copy the [`prepare_theme.sh`](./prepare_theme.sh) file to your project and run it to avoid having to remember to run all commands in step 4
+
+> Tip: Use the [`prepare_theme_pr.sh`](./prepare_theme_pr.sh) in your pull request builds to generate pull request specific overrides

--- a/prepare_theme.sh
+++ b/prepare_theme.sh
@@ -2,6 +2,8 @@ chmod +x theme_common/scripts/create-virtual-env.sh
 ./theme_common/scripts/create-virtual-env.sh
 source venv/bin/activate
 pip3 install -r theme_common/requirements.txt
-python3 theme_common/scripts/combine_theme_resources.py theme_common/resources theme_override/resources dist/_theme
+python3 theme_common/scripts/combine_theme_resources.py -s theme_common/resources -ov theme_override/resources -o dist/_theme
+# The next step is used to override resources for pull request builds - these overrides could as well have been put in the local theme_override folder, but this is a generic solution
+python3 theme_common/scripts/combine_theme_resources.py -s theme_common/resources_pr_specific -ov theme_override/resources -o dist/_theme -skiprmtree
 python3 theme_common/scripts/combine_mkdocs_config_yaml.py theme_common/mkdocs.yml theme_override/mkdocs.yml mkdocs.yml
 deactivate

--- a/prepare_theme_pr.sh
+++ b/prepare_theme_pr.sh
@@ -1,7 +1,10 @@
+# This script is meant to be used for pull request builds
 chmod +x theme_common/scripts/create-virtual-env.sh
 ./theme_common/scripts/create-virtual-env.sh
 source venv/bin/activate
 pip3 install -r theme_common/requirements.txt
 python3 theme_common/scripts/combine_theme_resources.py -s theme_common/resources -ov theme_override/resources -o dist/_theme
+# The next step is used to override resources for pull request builds - these overrides could as well have been put in the local theme_override folder, but this is a generic solution
+python3 theme_common/scripts/combine_theme_resources.py -s theme_common/resources_pr_specific -ov theme_override/resources -o dist/_theme -skiprmtree
 python3 theme_common/scripts/combine_mkdocs_config_yaml.py theme_common/mkdocs.yml theme_override/mkdocs.yml mkdocs.yml
 deactivate

--- a/resources/main.html
+++ b/resources/main.html
@@ -9,8 +9,8 @@
 {% endblock %}
 
 {% block outdated %}
-You're not viewing the latest version.
+This is documentation either for an old version, or for an unreleased 'main' version.
 <a href="{{ '../' ~ base_url }}">
-  <strong>Click here to go to latest.</strong>
+  <strong>Click here to go to the latest version.</strong>
 </a>
 {% endblock %}

--- a/resources_pr_specific/main.html
+++ b/resources_pr_specific/main.html
@@ -9,8 +9,8 @@
 {% endblock %}
 
 {% block outdated %}
-This documentation is either for an old version, or for the unreleased 'main' version.
-<a href="{{ '../' ~ base_url }}">
-  <strong>Click here to go to the latest version.</strong>
+This documentation comes from a pull request build and is unreleased, it is only used for review.
+<a href="https://docs.stakater.com/mto/">
+  <strong>Click here to go to the released documentation.</strong>
 </a>
 {% endblock %}

--- a/scripts/combine_theme_resources.py
+++ b/scripts/combine_theme_resources.py
@@ -1,12 +1,24 @@
-import shutil
+import argparse
 import os
-import sys
+import shutil
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-s', '--source', required=True, help='the source directory path')
+parser.add_argument('-ov', '--override', required=True, help='the override from directory path')
+parser.add_argument('-o', '--output', required=True, help='the output directory path')
+parser.add_argument('-skiprmtree', '--skiprmtree', required=False, action='store_true', help='skip removal of tree when copying submodule')
+args = parser.parse_args()
 
 def copy_submodule(source_dir, destination_dir):
     if os.path.exists(destination_dir):
-        shutil.rmtree(destination_dir)
-    shutil.copytree(source_dir, destination_dir)
-    print("Submodule copied to destination.")
+        if args.skiprmtree:
+            print(f'Skipping removal of {destination_dir}.')
+            shutil.copytree(source_dir, destination_dir, dirs_exist_ok=True)
+        else:
+            shutil.rmtree(destination_dir)
+            print(f'{destination_dir} removed.')
+            shutil.copytree(source_dir, destination_dir)
+    print(f'Submodule copied to {destination_dir}.')
 
 def override_resources(theme_override_dir, output_to_dir):
     source_override_dir = theme_override_dir
@@ -21,11 +33,8 @@ def override_resources(theme_override_dir, output_to_dir):
     print("Resources overridden.")
 
 if __name__ == "__main__":
-    if len(sys.argv) != 4:
-        print("Usage: python combine_theme_resources.py <source_dir_path> <override_from_dir_path> <output_dir_path>")
-        sys.exit(1)
-    source_dir_path = sys.argv[1]
-    overridefrom_dir_path = sys.argv[2]
-    output_dir_path = sys.argv[3]
+    source_dir_path = args.source
+    overridefrom_dir_path = args.override
+    output_dir_path = args.output
     copy_submodule(source_dir_path,output_dir_path)
     override_resources(overridefrom_dir_path, output_dir_path)


### PR DESCRIPTION
Update the outdated banner to notify the reader that they're either reading an old version of the documentation or that they're reading an unreleased version from `main`. This will be used in particular for https://github.com/stakater/mto-docs

Before updating the banner in MTO docs, the latest version needs to be updated in that pipeline to point to the latest released version, not to `main`, so these are prerequisite PRs:

* Enable setting latest doc version for multiple versioned doc: https://github.com/stakater/.github/pull/131
* Updating mto-docs to specify latest version: https://github.com/stakater/mto-docs/pull/199

Also updating the combine theme script to use `argparse` for better argument parsing, and to add the ability to skip removal of tree when copying submodule. This will be used when doing PR builds, so a subsequent PR will be needed after merge of this in `https://github.com/stakater/.github/.github/workflows/pull_request_versioned_doc.yaml` to use the new PR shell script.