### PR TITLE
Fix bug in prepare script and update copyright

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,4 +112,8 @@ Versioning is provided by `theme_override` and can be added to the `mkdocs.yml` 
 
 It is compiled under the `dist/_theme`
 
-> Tip: Copy the [`prepare_theme.sh`](./prepare_theme.sh) file to your project and run it to avoid having to remember to run all commands in step 4. Use the [`prepare_theme_pr.sh`](./prepare_theme_pr.sh) in your pull request builds to generate pull request specific overrides.
+> [!NOTE]
+> Copy the [`prepare_theme.sh`](./prepare_theme.sh) file to your project and run it to avoid having to remember to run all commands in step 4.
+>
+> [!NOTE]
+> Use the [`prepare_theme_pr.sh`](./prepare_theme_pr.sh) in your pull request builds to generate pull request specific overrides.

--- a/resources/partials/footer.html
+++ b/resources/partials/footer.html
@@ -129,7 +129,6 @@
             flex-direction: column;
         }
 
-
         .logo-footer-container {
             display: flex;
             justify-content: center;
@@ -203,7 +202,6 @@
             flex-direction: column;
         }
 
-
         .logo-footer-container {
             display: flex;
             justify-content: center;
@@ -253,7 +251,6 @@
     }
 </style>
 
-
 <footer class="md-footer">
     <div class="md-footer__inner mlr-auto" aria-label="{{ lang.t('footer') }}" {{ hidden }}>
         <!-- Footer content container-->
@@ -301,24 +298,19 @@
                             </b>
                         </p>
                         <p class="md-footer-org-details-md">
-
                             559066-6870
-
                         </p>
                     </div>
 
                     <div class="footer-location-info-container">
                         <p class="md-footer-col-title"><b>
-
                                 Address
                             </b>
                         </p>
                         <p class="md-footer-org-details-md">
-
                             David Bagares gata 26A, <br>
                             111 38 Stockholm, <br>
                             Sweden
-
                         </p>
                     </div>
                 </div>
@@ -328,34 +320,25 @@
                             Offerings
                         </b>
                     </p>
-
                     <div class="margin-bottom-16">
                         <a href="https://www.stakater.com/saap-kubernetes-openshift" class="md-footer-col-link">
-
                             Stakater App Agility <br>
                             Platform (SAAP)
-
                         </a>
                     </div>
                     <div class="margin-bottom-16">
                         <a href="https://www.stakater.com/mto" class="md-footer-col-link">
-
                             Multi Tenant Operator
-
                         </a>
                     </div>
                     <div class="margin-bottom-16">
                         <a href="https://www.stakater.com/kubernetes-platform-assessment" class="md-footer-col-link">
-
                             Platform Assessments
-
                         </a>
                     </div>
                     <div class="margin-bottom-16">
                         <a href="https://www.stakater.com/kubernetes-consultancy" class="md-footer-col-link">
-
                             Consultancy
-
                         </a>
                     </div>
                 </div>
@@ -363,38 +346,28 @@
                 <div class="flex-2">
                     <p class="md-footer-col-title">
                         <b>
-
                             Kubernetes Add-ons
                         </b>
                     </p>
-
                     <div class="margin-bottom-16">
                         <a href="https://github.com/stakater" class="md-footer-col-link">
-
                             Open Source Controllers
-
                         </a>
                     </div>
                     <div class="margin-bottom-16">
                         <a href="https://github.com/stakater/Reloader" class="md-footer-col-link">
-
                             Reloader
-
                         </a>
                     </div>
                     <div class="margin-bottom-16">
                         <a href="https://github.com/stakater/Forecastle" class="md-footer-col-link">
-
                             Forecastle
-
                         </a>
                     </div>
                     <div class="margin-bottom-16">
                         <a href="https://github.com/stakater/IngressMonitorController" class="md-footer-col-link">
-
                             Ingress Monitor <br>
                             Controller
-
                         </a>
                     </div>
                 </div>
@@ -405,19 +378,14 @@
                             Learning
                         </b>
                     </p>
-
                     <div class="margin-bottom-16">
                         <a href="https://www.stakater.com/events" class="md-footer-col-link">
-
                             Events and Recordings
-
                         </a>
                     </div>
                     <div class="margin-bottom-16">
                         <a href="https://docs.stakater.com/" class="md-footer-col-link">
-
                             Documentation
-
                         </a>
                     </div>
                 </div>
@@ -427,38 +395,28 @@
                             Company
                         </b>
                     </p>
-
                     <div class="margin-bottom-16">
                         <a href="https://www.stakater.com/faqs" class="md-footer-col-link">
-
                             FAQs
-
                         </a>
                     </div>
                     <div class="margin-bottom-16">
                         <a href="https://www.stakater.com/careers-and-jobs" class="md-footer-col-link">
-
                             Careers
-
                         </a>
                     </div>
                     <div class="margin-bottom-16">
                         <a href="https://www.stakater.com/contact-us" class="md-footer-col-link">
-
                             Contact Us
-
                         </a>
                     </div>
                     <div class="margin-bottom-16">
                         <a href="https://support.stakater.com/index.html" class="md-footer-col-link">
-
                             Support
-
                         </a>
                     </div>
                 </div>
             </div>
-
             <!-- Copy Rights and Social Media Links -->
             <div class="footer-copyrights-media-link-container">
                 <!-- Column 1 -->
@@ -467,7 +425,7 @@
                         <div>
                             <p class="md-footer-base-content">
                                 <b>
-                                    © 2023 Stakater.com
+                                    © 2024 Stakater
                                 </b>
                             </p>
                         </div>

--- a/resources_pr_specific/main.html
+++ b/resources_pr_specific/main.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block outdated %}
-This documentation comes from a pull request build and is unreleased, it is only used for review.
+This documentation is for a pull request deployment and is unreleased, it is only used for review of the PR.
 <a href="https://docs.stakater.com/mto/">
   <strong>Click here to go to the released documentation.</strong>
 </a>

--- a/scripts/combine_theme_resources.py
+++ b/scripts/combine_theme_resources.py
@@ -13,11 +13,10 @@ def copy_submodule(source_dir, destination_dir):
     if os.path.exists(destination_dir):
         if args.skiprmtree:
             print(f'Skipping removal of {destination_dir}.')
-            shutil.copytree(source_dir, destination_dir, dirs_exist_ok=True)
         else:
             shutil.rmtree(destination_dir)
             print(f'{destination_dir} removed.')
-            shutil.copytree(source_dir, destination_dir)
+    shutil.copytree(source_dir, destination_dir, dirs_exist_ok=args.skiprmtree)
     print(f'Submodule copied to {destination_dir}.')
 
 def override_resources(theme_override_dir, output_to_dir):


### PR DESCRIPTION
* A subtle bug got introduced in https://github.com/stakater/stakater-docs-mkdocs-theme/pull/52 where the copying of the generated tree with styling incorrectly was added inside the check for the output folder - the output folder never exists on the first run in PR builds, so the styling never got copied over during the build, and the output got rendered incorrectly
* Update copyright in footer