### PR TITLE
For PR builds, use announcement, not outdated banner

### DIFF
--- a/resources_pr_specific/main.html
+++ b/resources_pr_specific/main.html
@@ -8,8 +8,8 @@
 {% include "partials/footer.html" %}
 {% endblock %}
 
-{% block outdated %}
-This documentation is for a pull request deployment and is unreleased, it is only used for review of the PR.
+{% block announce %}
+This documentation is for a pull request deployment and is unreleased, it is only used for review of a PR.
 <a href="https://docs.stakater.com/mto/">
   <strong>Click here to go to the released documentation.</strong>
 </a>


### PR DESCRIPTION
All PR deployments should have an announcement banner to communicate that the deployment is from a PR deployment.

The currently used outdated banner will only display when the user is not on the latest version which is incorrect, this type of information should always show for all PR deployments.

Example of how it will appear:

![Screenshot 2024-11-17 at 21 01 14](https://github.com/user-attachments/assets/2afeeb20-403f-4160-ade3-6ce9e67eacff)
